### PR TITLE
Fix/host api

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/Impostor"]
-	path = src/Impostor
-	url = https://github.com/auproximity/Impostor

--- a/AUP-Impostor.sln
+++ b/AUP-Impostor.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AAA8C7BC-A3F6-4EE0-B42C-E89044BFBC74}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Electric.AUProximity", "src\Electric.AUProximity\Electric.AUProximity.csproj", "{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|x64.Build.0 = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Debug|x86.Build.0 = Debug|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|x64.ActiveCfg = Release|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|x64.Build.0 = Release|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|x86.ActiveCfg = Release|Any CPU
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{201C1C01-293C-4EEE-8B0F-35CA9A38FF35} = {AAA8C7BC-A3F6-4EE0-B42C-E89044BFBC74}
+	EndGlobalSection
+EndGlobal

--- a/src/Electric.AUProximity/AUProximityListener.cs
+++ b/src/Electric.AUProximity/AUProximityListener.cs
@@ -25,9 +25,13 @@ namespace Electric.AUProximity
         }
 
         [EventListener]
-        public void GameHostChangeEvent(IGameHostChangeEvent e)
+        public void GameHostChangedEvent(IGameHostChangedEvent e)
         {
-            _proximityHub.Clients.Group(e.Game.Code).HostChange(e.Host.Client.Name);
+            if (e.NewHost == null)
+            {
+                return; // No new host, game ending
+            }
+            _proximityHub.Clients.Group(e.Game.Code).HostChange(e.NewHost.Client.Name);
         }
 
         [EventListener]

--- a/src/Electric.AUProximity/AUProximityPlugin.cs
+++ b/src/Electric.AUProximity/AUProximityPlugin.cs
@@ -2,11 +2,7 @@
 
 namespace Electric.AUProximity
 {
-    [ImpostorPlugin(
-        package: "electric.auproximity",
-        name: "AUProximity Plugin",
-        author: "Cydon",
-        version: "0.2.0")]
+    [ImpostorPlugin("electric.auproximity")]
     public class AUProximity : PluginBase
     {
     }

--- a/src/Electric.AUProximity/Electric.AUProximity.csproj
+++ b/src/Electric.AUProximity/Electric.AUProximity.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Impostor\src\Impostor.Api\Impostor.Api.csproj" />
+      <ProjectReference Include="$(Impostor)\src\Impostor.Api\Impostor.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Electric.AUProximity/Electric.AUProximity.csproj
+++ b/src/Electric.AUProximity/Electric.AUProximity.csproj
@@ -5,6 +5,10 @@
         <OutputType>Library</OutputType>
         <RootNamespace>Electric.AUProximity</RootNamespace>
         <Nullable>enable</Nullable>
+
+        <Version>0.2.1</Version>
+        <AssemblyTitle>Plugin for AUProximity</AssemblyTitle>
+        <Authors>Cydon, miniduikboot</Authors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Electric.AUProximity/Hub/ProximityHub.cs
+++ b/src/Electric.AUProximity/Hub/ProximityHub.cs
@@ -21,7 +21,10 @@ namespace Electric.AUProximity.Hub
             if (game != null)
             {
                 await this.Clients.Group(gameCode).MapChange(game.Options.Map);
-                await this.Clients.Group(gameCode).HostChange(game.Host.Client.Name);
+                if (game.Host != null)
+                {
+                    await this.Clients.Group(gameCode).HostChange(game.Host.Client.Name);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR updates the plugin to account for changes in Impostor's API: the stabilized version of the API is named slightly differently and one argument is now nullable

It also moves the plugin to import impostor from an environment variable and applies the latest changes to the plugin api.

After this PR is merged we should release 0.2.1 of the plugin